### PR TITLE
Cache the TM and XAR references and remove the SQL code because we won't...

### DIFF
--- a/narayana/ArjunaJTA/jta/pom.xml
+++ b/narayana/ArjunaJTA/jta/pom.xml
@@ -105,6 +105,11 @@
     </build>
 
     <dependencies>
+      <dependency>
+         <groupId>org.jboss.netty</groupId>
+         <artifactId>netty</artifactId>
+         <version>3.2.5.Final</version>
+      </dependency>
         <!-- JTA (local: ArjunaJTA/jta and remote: ArjunaJTS/jtax) need JTA and
                 JCA (for tx inflow) apis. -->
         <dependency>

--- a/narayana/ArjunaJTA/jta/tests/classes/io/narayana/perf/product/ProductComparison.java
+++ b/narayana/ArjunaJTA/jta/tests/classes/io/narayana/perf/product/ProductComparison.java
@@ -44,16 +44,15 @@ import bitronix.tm.utils.DefaultExceptionAnalyzer;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
-import com.arjuna.ats.internal.arjuna.objectstore.VolatileStore;
+import com.arjuna.ats.internal.arjuna.objectstore.hornetq.HornetqJournalEnvironmentBean;
 import com.arjuna.ats.jta.xa.performance.JMHConfigJTA;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 import com.atomikos.icatch.jta.UserTransactionManager;
 
-
 @State(Scope.Benchmark)
 public class ProductComparison {
     final protected static String METHOD_SEP = "_";
-    final private static String outerClassName =  ProductComparison.class.getName();
+    final private static String outerClassName = ProductComparison.class.getName();
     final static private String narayanaMetricName = outerClassName + METHOD_SEP + "Narayana";
 
     public static void main(String[] args) throws RunnerException, CommandLineOptionException, CoreEnvironmentBeanException {
@@ -119,7 +118,12 @@ public class ProductComparison {
             } catch (CoreEnvironmentBeanException e) {
                 e.printStackTrace();
             }
-            BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class).setObjectStoreType(VolatileStore.class.getName());
+            HornetqJournalEnvironmentBean hornetqJournalEnvironmentBean = BeanPopulator.getDefaultInstance(
+                com.arjuna.ats.internal.arjuna.objectstore.hornetq.HornetqJournalEnvironmentBean.class
+                );
+            hornetqJournalEnvironmentBean.setAsyncIO(true);
+            hornetqJournalEnvironmentBean.setStoreDir("HornetqObjectStore");
+            BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class).setObjectStoreType("com.arjuna.ats.internal.arjuna.objectstore.hornetq.HornetqObjectStoreAdaptor");
             ut = com.arjuna.ats.jta.UserTransaction.userTransaction();
             tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
         }
@@ -215,7 +219,7 @@ public class ProductComparison {
 
         @Override
         public TransactionManager getTransactionManager() {
-              return utm;
+            return utm;
         }
 
         @Override

--- a/narayana/ArjunaJTA/jta/tests/classes/io/narayana/perf/product/ProductComparison.java
+++ b/narayana/ArjunaJTA/jta/tests/classes/io/narayana/perf/product/ProductComparison.java
@@ -21,10 +21,26 @@
  */
 package io.narayana.perf.product;
 
+import javax.sql.DataSource;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.CommandLineOptionException;
+
 import bitronix.tm.BitronixTransactionManager;
 import bitronix.tm.TransactionManagerServices;
-
 import bitronix.tm.utils.DefaultExceptionAnalyzer;
+
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
@@ -32,13 +48,6 @@ import com.arjuna.ats.internal.arjuna.objectstore.VolatileStore;
 import com.arjuna.ats.jta.xa.performance.JMHConfigJTA;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 import com.atomikos.icatch.jta.UserTransactionManager;
-import org.junit.*;
-import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.CommandLineOptionException;
-
-import javax.sql.DataSource;
-import javax.transaction.*;
 
 
 @State(Scope.Benchmark)
@@ -126,11 +135,6 @@ public class ProductComparison {
         @Override
         public UserTransaction getUserTransaction() throws SystemException {
             return jotm.getUserTransaction();
-/*                try {
-                    return (UserTransaction) new InitialContext().lookup("UserTransaction");
-                } catch (NamingException e) {
-                    throw new SystemException(e.getMessage());
-                }*/
         }
 
         @Override
@@ -187,22 +191,6 @@ public class ProductComparison {
         public String getNameOfMetric() {
             return outerClassName + "_Bitronix";
         }
-/*
-        private DataSource initDataSource(){
-            PoolingDataSource pds = new PoolingDataSource();
-            //   org.h2.jdbcx.JdbcDataSource
-            pds.setUniqueName("jdbc/jmh-ds");
-            pds.setClassName("bitronix.tm.resource.jdbc.lrc.LrcXADataSource");
-            pds.setMaxPoolSize(5);
-            pds.setAllowLocalTransactions(false);
-            pds.getDriverProperties().put("user","sa");
-            pds.getDriverProperties().put("password","sa");
-            pds.getDriverProperties().put("url","jdbc:h2:tcp://localhost/~/jmhdb.h2.db");
-            pds.getDriverProperties().put("driverClassName","org.h2.Driver");
-            pds.init();
-
-            return pds;
-        }*/
 
         @Override
         public void init() {
@@ -228,7 +216,6 @@ public class ProductComparison {
         @Override
         public TransactionManager getTransactionManager() {
               return utm;
-//            return com.atomikos.icatch.jta.TransactionManagerImp.getTransactionManager();
         }
 
         @Override

--- a/narayana/ArjunaJTA/jta/tests/classes/io/narayana/perf/product/btm/BtmXAResourceHolderState.java
+++ b/narayana/ArjunaJTA/jta/tests/classes/io/narayana/perf/product/btm/BtmXAResourceHolderState.java
@@ -28,13 +28,13 @@ import bitronix.tm.resource.common.XAResourceHolder;
 import javax.transaction.xa.XAResource;
 
 public class BtmXAResourceHolderState extends XAResourceHolderState {
+    private XAResource xar;
+    private ResourceBean bean;
+    
     @Override
     public String getUniqueName() {
         return "bitronix";
     }
-
-    private XAResource xar;
-    ResourceBean bean;
 
     public BtmXAResourceHolderState(XAResourceHolder resourceHolder, ResourceBean bean) {
         super(resourceHolder, bean);

--- a/narayana/ArjunaJTA/jta/tests/classes/io/narayana/perf/product/btm/BtmXAResourceProducer.java
+++ b/narayana/ArjunaJTA/jta/tests/classes/io/narayana/perf/product/btm/BtmXAResourceProducer.java
@@ -30,12 +30,10 @@ import javax.naming.Reference;
 import javax.transaction.xa.XAResource;
 
 public class BtmXAResourceProducer implements XAResourceProducer {
-    private XAResource[] xars;
     private BtmXAResourceHolderState btmRecovery;
-    XAResourceHolder[] xarHolders;
+    private XAResourceHolder[] xarHolders;
 
     public BtmXAResourceProducer(BtmXAResourceHolderState btmRecovery, XAResource ... xars) {
-        this.xars = xars;
         this.btmRecovery = btmRecovery;
         this.xarHolders = new XAResourceHolder[xars.length];
 


### PR DESCRIPTION
The changes I made were so I could easily see the code that was going to be used. The main functional change was to change to cache the reference to the transaction manager as I imagine most apps would cache that reference.