### PR TITLE
[JBTM-3003] using ci wildfly instead of jboss one which seems to be down

### DIFF
--- a/comparison/common/src/main/java/org/jboss/narayana/performance/common/test/AbstractTestCase.java
+++ b/comparison/common/src/main/java/org/jboss/narayana/performance/common/test/AbstractTestCase.java
@@ -41,12 +41,17 @@ import org.jboss.as.cli.CommandLineException;
  *
  */
 public abstract class AbstractTestCase {
+    protected static final int HTTP_REMOTING_PORT = 9990;
+    protected static final int HTTP_PORT = 8080;
 
     protected static final String CLIENT_CONTAINER_NAME = "server1";
+    protected static final int CLIENT_CONTAINER_OFFSET = 100;
 
     protected static final String FIRST_SERVICE_CONTAINER_NAME = "server2";
+    protected static final int FIRST_SERVICE_CONTAINER_OFFSET = 200;
 
     protected static final String SECOND_SERVICE_CONTAINER_NAME = "server3";
+    protected static final int SECOND_SERVICE_CONTAINER_OFFSET = 300;
 
     protected static final String CLIENT_DEPLOYMENT_NAME = "client-deployment";
 
@@ -54,11 +59,12 @@ public abstract class AbstractTestCase {
 
     protected static final String SECOND_SERVICE_DEPLOYMENT_NAME = "second-service-deployment";
 
-    protected static final String CLIENT_CONTROLLER = "http-remoting://localhost:9990";
 
-    protected static final String FIRST_SERVICE_CONTROLLER = "http-remoting://localhost:10090";
+    protected static final String CLIENT_CONTROLLER = "http-remoting://localhost:" + (HTTP_REMOTING_PORT + CLIENT_CONTAINER_OFFSET);
 
-    protected static final String SECOND_SERVICE_CONTROLLER = "http-remoting://localhost:10190";
+    protected static final String FIRST_SERVICE_CONTROLLER = "http-remoting://localhost:" + (HTTP_REMOTING_PORT + FIRST_SERVICE_CONTAINER_OFFSET);
+
+    protected static final String SECOND_SERVICE_CONTROLLER = "http-remoting://localhost:" + (HTTP_REMOTING_PORT + SECOND_SERVICE_CONTAINER_OFFSET);
 
     protected final String numberOfThreads;
 
@@ -80,13 +86,16 @@ public abstract class AbstractTestCase {
 
     protected void startContainers() {
         final Map<String, String> config1 = new Config().add("javaVmArguments",
-                System.getProperty("server1.jvm.args").trim()).map();
+                System.getProperty("server1.jvm.args").trim() + " -Djboss.socket.binding.port-offset="
+                        + CLIENT_CONTAINER_OFFSET + " -Djboss.node.name=" + CLIENT_CONTAINER_NAME).map();
 
         final Map<String, String> config2 = new Config().add("javaVmArguments",
-                System.getProperty("server2.jvm.args").trim() + " -Djboss.socket.binding.port-offset=100").map();
+                System.getProperty("server2.jvm.args").trim() + " -Djboss.socket.binding.port-offset="
+                        + FIRST_SERVICE_CONTAINER_OFFSET + " -Djboss.node.name=" + FIRST_SERVICE_CONTAINER_NAME).map();
 
         final Map<String, String> config3 = new Config().add("javaVmArguments",
-                System.getProperty("server3.jvm.args").trim() + " -Djboss.socket.binding.port-offset=200").map();
+                System.getProperty("server3.jvm.args").trim() + " -Djboss.socket.binding.port-offset="
+                        + SECOND_SERVICE_CONTAINER_OFFSET  + " -Djboss.node.name=" + SECOND_SERVICE_CONTAINER_NAME).map();
 
         controller.start(CLIENT_CONTAINER_NAME, config1);
         controller.start(FIRST_SERVICE_CONTAINER_NAME, config2);

--- a/comparison/jts/pom.xml
+++ b/comparison/jts/pom.xml
@@ -87,12 +87,9 @@
                             <skip>false</skip>
                             <systemPropertyVariables combine.children="append">
                                 <arquillian.launch>wildfly-cluster</arquillian.launch>
-                                <server1.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server1.jvm.args>
-                                <server2.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server2.jvm.args>
-                                <server3.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server3.jvm.args>
+                                <server1.jvm.args>${jvm.args.other} ${jvm.args.memory}</server1.jvm.args>
+                                <server2.jvm.args>${jvm.args.other} ${jvm.args.memory}</server2.jvm.args>
+                                <server3.jvm.args>${jvm.args.other} ${jvm.args.memory}</server3.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -146,10 +143,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server1.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server1.jvm.args>
+                                <server1.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server1.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -168,10 +162,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server2.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server2.jvm.args>
+                                <server2.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server2.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -190,10 +181,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server3.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server3.jvm.args>
+                                <server3.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server3.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/comparison/jts/src/main/java/org/jboss/narayana/performance/jts/client/TestExecutor.java
+++ b/comparison/jts/src/main/java/org/jboss/narayana/performance/jts/client/TestExecutor.java
@@ -30,10 +30,10 @@ public class TestExecutor {
 
     public static final Logger LOG = Logger.getLogger(TestExecutor.class);
 
-    @EJB(lookup = "corbaname:iiop:localhost:3628#jts/FirstEJBImpl")
+    @EJB(lookup = "corbaname:iiop:localhost:3728#jts/FirstEJBImpl")
     private FirstEJBHome firstEJBHome;
 
-    @EJB(lookup = "corbaname:iiop:localhost:3728#jts/SecondEJBImpl")
+    @EJB(lookup = "corbaname:iiop:localhost:3828#jts/SecondEJBImpl")
     private SecondEJBHome secondEJBHome;
 
     @GET

--- a/comparison/jts/src/test/java/org/jboss/narayana/jts/TestCase.java
+++ b/comparison/jts/src/test/java/org/jboss/narayana/jts/TestCase.java
@@ -36,8 +36,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class TestCase extends AbstractTestCase {
 
-    private static final String EXECUTOR_URL = "http://127.0.0.1:8180/" + CLIENT_DEPLOYMENT_NAME + "/"
-            + TestExecutor.RESOURCE_PATH;
+    private static final String EXECUTOR_URL = "http://127.0.0.1:" + (HTTP_PORT + CLIENT_CONTAINER_OFFSET)
+            + "/" + CLIENT_DEPLOYMENT_NAME + "/" + TestExecutor.RESOURCE_PATH;
 
     @Deployment(name = CLIENT_DEPLOYMENT_NAME, managed = false, testable = false)
     @TargetsContainer(CLIENT_CONTAINER_NAME)

--- a/comparison/jts/src/test/resources/arquillian.xml
+++ b/comparison/jts/src/test/resources/arquillian.xml
@@ -3,40 +3,34 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="Servlet 3.0"/>
+
     <group qualifier="wildfly-cluster">
         <container qualifier="server1" default="true" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/server1</property>
-                <property name="javaVmArguments">
-                    ${server1.jvm.args} -Djboss.inst=${basedir}/target/server1 -Djboss.node.name=server1
-                </property>
-                <property name="serverConfig">standalone-full.xml</property>
-                <property name="managementAddress">127.0.0.1</property>
-                <property name="managementPort">9990</property>
-            </configuration>
-        </container>
-
-        <container qualifier="server2" default="false" mode="manual">
-            <configuration>
-                <property name="jbossHome">${basedir}/target/server2</property>
-                <property name="javaVmArguments">
-                    ${server2.jvm.args} -Djboss.inst=${basedir}/target/server2 -Djboss.node.name=server2
-                </property>
+                <!-- as manual mode the javaVmArguments reset at org.jboss.narayana.performance.common.test.AbstractTestCase -->
                 <property name="serverConfig">standalone-full.xml</property>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">10090</property>
             </configuration>
         </container>
 
-        <container qualifier="server3" default="false" mode="manual">
+        <container qualifier="server2" default="false" mode="manual">
             <configuration>
-                <property name="jbossHome">${basedir}/target/server3</property>
-                <property name="javaVmArguments">
-                    ${server3.jvm.args} -Djboss.inst=${basedir}/target/server3 -Djboss.node.name=server3
-                </property>
+                <property name="jbossHome">${basedir}/target/server2</property>
                 <property name="serverConfig">standalone-full.xml</property>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">10190</property>
+            </configuration>
+        </container>
+
+        <container qualifier="server3" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/server3</property>
+                <property name="serverConfig">standalone-full.xml</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">10290</property>
             </configuration>
         </container>
     </group>

--- a/comparison/pom.xml
+++ b/comparison/pom.xml
@@ -19,8 +19,8 @@
 
         <!-- Dependency versions -->
         <version.arquillian>1.1.11.Final</version.arquillian>
-        <version.arquillian.wildfly.container>2.0.0.Final</version.arquillian.wildfly.container>
-        <version.wildfly.core>3.0.0.Alpha5</version.wildfly.core>
+        <version.arquillian.wildfly.container>2.1.0.Final</version.arquillian.wildfly.container>
+        <version.wildfly.core>5.0.0.Alpha1</version.wildfly.core>
         <version.org.jboss.narayana>5.8.1.Final-SNAPSHOT</version.org.jboss.narayana>
         <version.org.jboss.spec.javax.ejb>1.0.0.Final</version.org.jboss.spec.javax.ejb>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
@@ -98,11 +98,6 @@
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-container-managed</artifactId>
-                <version>${version.arquillian.wildfly.container}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.arquillian</groupId>
-                <artifactId>wildfly-arquillian-common</artifactId>
                 <version>${version.arquillian.wildfly.container}</version>
             </dependency>
             <dependency>

--- a/comparison/rest-at/pom.xml
+++ b/comparison/rest-at/pom.xml
@@ -91,12 +91,9 @@
                             <skip>false</skip>
                             <systemPropertyVariables combine.children="append">
                                 <arquillian.launch>wildfly-cluster</arquillian.launch>
-                                <server1.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server1.jvm.args>
-                                <server2.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server2.jvm.args>
-                                <server3.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server3.jvm.args>
+                                <server1.jvm.args>${jvm.args.other} ${jvm.args.memory}</server1.jvm.args>
+                                <server2.jvm.args>${jvm.args.other} ${jvm.args.memory}</server2.jvm.args>
+                                <server3.jvm.args>${jvm.args.other} ${jvm.args.memory}</server3.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -158,10 +155,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server1.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server1.jvm.args>
+                                <server1.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server1.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -180,10 +174,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server2.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server2.jvm.args>
+                                <server2.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server2.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -202,10 +193,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server3.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server3.jvm.args>
+                                <server3.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server3.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/comparison/rest-at/src/test/java/org/jboss/narayana/performance/rts/TestCase.java
+++ b/comparison/rest-at/src/test/java/org/jboss/narayana/performance/rts/TestCase.java
@@ -37,14 +37,14 @@ public class TestCase extends AbstractTestCase {
 
     private static final String BASE_URL = "http://127.0.0.1";
 
-    private static final String EXECUTOR_URL = BASE_URL + ":8180/" + CLIENT_DEPLOYMENT_NAME + "/"
-            + TestExecutor.RESOURCE_PATH;
+    private static final String EXECUTOR_URL = BASE_URL + ":" + (HTTP_PORT + CLIENT_CONTAINER_OFFSET)
+            + "/" + CLIENT_DEPLOYMENT_NAME + "/" + TestExecutor.RESOURCE_PATH;
 
-    private static final String FIRST_SERVICE_URL = BASE_URL + ":8180/" + FIRST_SERVICE_DEPLOYMENT_NAME;
+    private static final String FIRST_SERVICE_URL = BASE_URL + ":" + (HTTP_PORT + FIRST_SERVICE_CONTAINER_OFFSET) + "/" + FIRST_SERVICE_DEPLOYMENT_NAME;
 
-    private static final String SECOND_SERVICE_URL = BASE_URL + ":8280/" + SECOND_SERVICE_DEPLOYMENT_NAME;
+    private static final String SECOND_SERVICE_URL = BASE_URL + ":" + (HTTP_PORT + SECOND_SERVICE_CONTAINER_OFFSET) + "/" + SECOND_SERVICE_DEPLOYMENT_NAME;
 
-    private static final String COORDINATOR_URL = BASE_URL + ":8180/rest-at-coordinator/tx/transaction-manager";
+    private static final String COORDINATOR_URL = BASE_URL + ":" + (HTTP_PORT + CLIENT_CONTAINER_OFFSET) + "/rest-at-coordinator/tx/transaction-manager";
 
     @Deployment(name = CLIENT_DEPLOYMENT_NAME, managed = false, testable = false)
     @TargetsContainer(CLIENT_CONTAINER_NAME)

--- a/comparison/rest-at/src/test/resources/arquillian.xml
+++ b/comparison/rest-at/src/test/resources/arquillian.xml
@@ -3,43 +3,34 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="Servlet 3.0"/>
+
     <group qualifier="wildfly-cluster">
         <container qualifier="server1" default="true" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/server1</property>
-                <property name="javaVmArguments">
-                    ${server1.jvm.args} -Djboss.inst=${basedir}/target/server1 -Djboss.node.name=server1
-                </property>
+                <!-- as manual mode the javaVmArguments reset at org.jboss.narayana.performance.common.test.AbstractTestCase -->
                 <property name="serverConfig">standalone-rts.xml</property>
                 <property name="managementAddress">127.0.0.1</property>
-                <property name="managementPort">9990</property>
-                <property name="httpPort">8180</property>
+                <property name="managementPort">10090</property>
             </configuration>
         </container>
 
         <container qualifier="server2" default="false" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/server2</property>
-                <property name="javaVmArguments">
-                    ${server2.jvm.args} -Djboss.inst=${basedir}/target/server2 -Djboss.node.name=server2
-                </property>
                 <property name="serverConfig">standalone-rts.xml</property>
                 <property name="managementAddress">127.0.0.1</property>
-                <property name="managementPort">10090</property>
-                <property name="httpPort">8280</property>
+                <property name="managementPort">10190</property>
             </configuration>
         </container>
 
         <container qualifier="server3" default="false" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/server3</property>
-                <property name="javaVmArguments">
-                    ${server3.jvm.args} -Djboss.inst=${basedir}/target/server3 -Djboss.node.name=server3
-                </property>
                 <property name="serverConfig">standalone-rts.xml</property>
                 <property name="managementAddress">127.0.0.1</property>
-                <property name="managementPort">10190</property>
-                <property name="httpPort">8380</property>
+                <property name="managementPort">10290</property>
             </configuration>
         </container>
     </group>

--- a/comparison/ws-at/pom.xml
+++ b/comparison/ws-at/pom.xml
@@ -87,12 +87,9 @@
                             <skip>false</skip>
                             <systemPropertyVariables combine.children="append">
                                 <arquillian.launch>wildfly-cluster</arquillian.launch>
-                                <server1.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server1.jvm.args>
-                                <server2.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server2.jvm.args>
-                                <server3.jvm.args>${jvm.args.other}
-                                    ${jvm.args.memory}</server3.jvm.args>
+                                <server1.jvm.args>${jvm.args.other} ${jvm.args.memory}</server1.jvm.args>
+                                <server2.jvm.args>${jvm.args.other} ${jvm.args.memory}</server2.jvm.args>
+                                <server3.jvm.args>${jvm.args.other} ${jvm.args.memory}</server3.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -154,10 +151,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server1.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server1.jvm.args>
+                                <server1.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server1.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -176,10 +170,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server2.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server2.jvm.args>
+                                <server2.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server2.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
@@ -198,10 +189,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables combine.children="append">
-                                <server3.jvm.args>
-                                    ${jvm.args.other}
-                                    ${jvm.args.memory} ${jvm.args.debug}
-                                </server3.jvm.args>
+                                <server3.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug}</server3.jvm.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/comparison/ws-at/src/main/java/org/jboss/narayana/performance/xts/service/first/FirstServiceClientFactory.java
+++ b/comparison/ws-at/src/main/java/org/jboss/narayana/performance/xts/service/first/FirstServiceClientFactory.java
@@ -12,7 +12,7 @@ import javax.xml.ws.Service;
 public class FirstServiceClientFactory {
 
     public static FirstService getInstance() throws MalformedURLException {
-        final URL wsdlLocation = new URL("http://localhost:8180/first-service-deployment/FirstServiceService/FirstService?wsdl");
+        final URL wsdlLocation = new URL("http://localhost:8280/first-service-deployment/FirstServiceService/FirstService?wsdl");
         final QName serviceName = new QName("http://www.narayana.io", "FirstServiceService");
         final QName portName = new QName("http://www.narayana.io", "FirstService");
 

--- a/comparison/ws-at/src/main/java/org/jboss/narayana/performance/xts/service/second/SecondServiceClientFactory.java
+++ b/comparison/ws-at/src/main/java/org/jboss/narayana/performance/xts/service/second/SecondServiceClientFactory.java
@@ -12,7 +12,7 @@ import javax.xml.ws.Service;
 public class SecondServiceClientFactory {
 
     public static SecondService getInstance() throws MalformedURLException {
-        final URL wsdlLocation = new URL("http://localhost:8280/second-service-deployment/SecondServiceService/SecondService?wsdl");
+        final URL wsdlLocation = new URL("http://localhost:8380/second-service-deployment/SecondServiceService/SecondService?wsdl");
         final QName serviceName = new QName("http://www.narayana.io", "SecondServiceService");
         final QName portName = new QName("http://www.narayana.io", "SecondService");
 

--- a/comparison/ws-at/src/test/java/org/jboss/narayana/performance/xts/TestCase.java
+++ b/comparison/ws-at/src/test/java/org/jboss/narayana/performance/xts/TestCase.java
@@ -35,8 +35,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class TestCase extends AbstractTestCase {
 
-    private static final String EXECUTOR_URL = "http://127.0.0.1:8180/" + CLIENT_DEPLOYMENT_NAME + "/"
-            + TestExecutor.RESOURCE_PATH;
+    private static final String EXECUTOR_URL = "http://127.0.0.1:" + (HTTP_PORT + CLIENT_CONTAINER_OFFSET)
+            + "/" + CLIENT_DEPLOYMENT_NAME + "/" + TestExecutor.RESOURCE_PATH;
 
     @Deployment(name = CLIENT_DEPLOYMENT_NAME, managed = false, testable = false)
     @TargetsContainer(CLIENT_CONTAINER_NAME)

--- a/comparison/ws-at/src/test/resources/arquillian.xml
+++ b/comparison/ws-at/src/test/resources/arquillian.xml
@@ -3,43 +3,34 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="Servlet 3.0"/>
+
     <group qualifier="wildfly-cluster">
         <container qualifier="server1" default="true" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/server1</property>
-                <property name="javaVmArguments">
-                    ${server1.jvm.args} -Djboss.inst=${basedir}/target/server1 -Djboss.node.name=server1
-                </property>
+                <!-- as manual mode the javaVmArguments reset at org.jboss.narayana.performance.common.test.AbstractTestCase -->
                 <property name="serverConfig">standalone-xts.xml</property>
                 <property name="managementAddress">127.0.0.1</property>
-                <property name="managementPort">9990</property>
-                <property name="httpPort">8180</property>
+                <property name="managementPort">10090</property>
             </configuration>
         </container>
 
         <container qualifier="server2" default="false" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/server2</property>
-                <property name="javaVmArguments">
-                    ${server2.jvm.args} -Djboss.inst=${basedir}/target/server2 -Djboss.node.name=server2
-                </property>
                 <property name="serverConfig">standalone-xts.xml</property>
                 <property name="managementAddress">127.0.0.1</property>
-                <property name="managementPort">10090</property>
-                <property name="httpPort">8280</property>
+                <property name="managementPort">10190</property>
             </configuration>
         </container>
 
         <container qualifier="server3" default="false" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/server3</property>
-                <property name="javaVmArguments">
-                    ${server3.jvm.args} -Djboss.inst=${basedir}/target/server3 -Djboss.node.name=server3
-                </property>
                 <property name="serverConfig">standalone-xts.xml</property>
                 <property name="managementAddress">127.0.0.1</property>
-                <property name="managementPort">10190</property>
-                <property name="httpPort">8380</property>
+                <property name="managementPort">10290</property>
             </configuration>
         </container>
     </group>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3003

WildFly distribution was not downloaded for the use in the performance test. It seems the ci.jboss.org is down and as said the WFLY nightly builds are available: https://developer.jboss.org/thread/224262

The updated link which works is:
https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastFinished/wildfly-13.0.0.Alpha1-SNAPSHOT.zip
but such link needs to be changed each time the version of wfly is bumped. Using curl with downloading `artifacts` (zip + src) of the ci job while using the zip.