### PR TITLE
Fix for RuntimeException: Failed to parse bin/jboss-cli.xml

### DIFF
--- a/comparison/pom.xml
+++ b/comparison/pom.xml
@@ -20,7 +20,7 @@
         <!-- Dependency versions -->
         <version.arquillian>1.1.11.Final</version.arquillian>
         <version.arquillian.wildfly.container>2.1.0.Final</version.arquillian.wildfly.container>
-        <version.wildfly.core>5.0.0.Alpha1</version.wildfly.core>
+        <version.wildfly.core>5.0.0.Final</version.wildfly.core>
         <version.org.jboss.narayana>5.8.3.Final-SNAPSHOT</version.org.jboss.narayana>
         <version.org.jboss.spec.javax.ejb>1.0.0.Final</version.org.jboss.spec.javax.ejb>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>


### PR DESCRIPTION
as `wildfly-cli` changed from Alpha1 version and probably the syntax and records in the `jboss-cli.xml` changed too
