### PR TITLE
Test instability fixing - ServiceUnavailableException: HTTP 503 Service Unavailbale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@ target
 .project
 .classpath
 .settings
+.checkstyle
 *.iml
 .idea
 jboss-as
 *.swp
 *~
 CosServices.cfg
+ObjectStore/
+logs/

--- a/narayana/ArjunaJTA/jta/tests/classes/org/jboss/narayana/rts/TransactionAwareResource.java
+++ b/narayana/ArjunaJTA/jta/tests/classes/org/jboss/narayana/rts/TransactionAwareResource.java
@@ -140,7 +140,7 @@ public class TransactionAwareResource {
 
         reqHeaders.put("Link", linkHeader);
 
-        return new TxSupport().httpRequest(new int[] {HttpURLConnection.HTTP_CREATED}, enlistUrl, "POST",
+        return new TxSupport(0).httpRequest(new int[] {HttpURLConnection.HTTP_CREATED}, enlistUrl, "POST",
                 TxMediaType.POST_MEDIA_TYPE, null, null, reqHeaders);
     }
 


### PR DESCRIPTION
It happens there is thrown exception

```
javax.ws.rs.ServiceUnavailableException: HTTP 503 Service Unavailable
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.handleErrorStatus(ClientInvocation.java:191)
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.extractResult(ClientInvocation.java:154)
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.invoke(ClientInvocation.java:444)
    at org.jboss.narayana.rts.TxnHelper.sendRequest(TxnHelper.java:87)
    at org.jboss.narayana.rts.TxnTest.testTxn(TxnTest.java:66)
```

See e.g. http://narayanaci1.eng.hst.ams2.redhat.com/job/narayana-performance/84

which seems to be an intermittent failure. It seems the timeout of 20s could not be enough for processing enlistment of a resource at the transaction manager during the performance load and the tests starts to fail.

This PR sets the timeout connection timeout for the rest participant enlistment to infinite.
(the error reproduced on the local machine when the timeout was set to 5ms)

/cc @tomjenkinson 