### PR TITLE
Changing Undertow version to 2.0.16 and adding rebase script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@ target
 .project
 .classpath
 .settings
+.checkstyle
 *.iml
 .idea
 jboss-as
 *.swp
 *~
 CosServices.cfg
+ObjectStore/
+logs/

--- a/narayana/ArjunaJTA/jta/pom.xml
+++ b/narayana/ArjunaJTA/jta/pom.xml
@@ -47,7 +47,7 @@
 
         <!-- RTS -->
         <rts.version>${project.version}</rts.version>
-        <undertow.io.version>1.3.31.Final</undertow.io.version>
+        <undertow.io.version>2.0.16.Final</undertow.io.version>
         <resteasy.version>3.0.11.Final</resteasy.version>
 
         <version.org.apache.activemq>1.1.0.wildfly-010</version.org.apache.activemq>

--- a/scripts/hudson/performance-rebase.sh
+++ b/scripts/hudson/performance-rebase.sh
@@ -1,0 +1,44 @@
+export GIT_ACCOUNT=${GIT_ACCOUNT:-jbosstm}
+export GIT_REPO=${GIT_REPO:-performance}
+
+function fatal {
+  comment_on_pull "Tests failed ($BUILD_URL): $1"
+  echo "$1"
+  exit 1
+}
+
+function comment_on_pull
+{
+    if [ "$COMMENT_ON_PULL" = "" ]; then return; fi
+
+    PULL_NUMBER=$(echo $GIT_BRANCH | awk -F 'pull' '{ print $2 }' | awk -F '/' '{ print $2 }')
+    if [ "$PULL_NUMBER" != "" ]
+    then
+        JSON="{ \"body\": \"$1\" }"
+        curl -d "$JSON" -ujbosstm-bot:$BOT_PASSWORD https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
+    else
+        echo "Not a pull request, so not commenting"
+    fi
+}
+
+function rebase_performance {
+  echo "Rebasing Performance repository"
+  cd $WORKSPACE
+
+  # Clean up the local repo
+  git rebase --abort
+  rm -rf .git/rebase-apply
+  git clean -f -d -x
+  
+  export BRANCHPOINT=master
+
+  # Update the pull to head  
+  git pull --rebase --ff-only origin $BRANCHPOINT
+
+  if [ $? -ne 0 ]; then
+    fatal "Performance rebase on $BRANCHPOINT failed. Please rebase it manually"
+  fi
+}
+
+rebase_performance "$@"
+exit 0


### PR DESCRIPTION
The PR was lead by investigation of the failure which causes intermittent failures with error

```
javax.ws.rs.ServiceUnavailableException: HTTP 503 Service Unavailable
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.handleErrorStatus(ClientInvocation.java:191)
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.extractResult(ClientInvocation.java:154)
    at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.invoke(ClientInvocation.java:444)
    at org.jboss.narayana.rts.TxnHelper.sendRequest(TxnHelper.java:87)
    at org.jboss.narayana.rts.TxnTest.testTxn(TxnTest.java:66)
```
This error was at the rest-at tests.  After long lasting investigation it seems it was caused by Undertow stopped to listen on the test port 8090. The reason why it happens is hard to find and I'm not sure.

Bumping version of Undertow was a try to fix the error. The change of the version did not fix the issue but the version update is still reasonable.