### PR TITLE
Work on performance runs

### DIFF
--- a/narayana/ArjunaJTA/jta/etc/jbossts-properties.xml
+++ b/narayana/ArjunaJTA/jta/etc/jbossts-properties.xml
@@ -8,10 +8,8 @@
         <entry key="HornetqJournalEnvironmentBean.asyncIO">true</entry>
         <entry key="HornetqJournalEnvironmentBean.storeDir">target/narayana</entry>
         <!-- default for NIO is 300 and for AIO it's 2000 -->
-        <entry key="HornetqJournalEnvironmentBean.bufferFlushesPerSecond">7812</entry>
-	<!--
+<!--         <entry key="HornetqJournalEnvironmentBean.bufferFlushesPerSecond">7812</entry> -->
         <entry key="HornetqJournalEnvironmentBean.bufferFlushesPerSecond">4000</entry>
-        -->
         <entry key="HornetqJournalEnvironmentBean.syncDeletes">false</entry>
         <!-- default for NIO is 1 and for AIO it's 500 -->
         <entry key="HornetqJournalEnvironmentBean.maxIO">500</entry>

--- a/narayana/ArjunaJTA/jta/etc/jotm.properties
+++ b/narayana/ArjunaJTA/jta/etc/jotm.properties
@@ -10,8 +10,8 @@ howl.log.ListConfiguation        false
 howl.log.BufferSize              4
 howl.log.MinimumBuffers          16
 howl.log.MaximumBuffers          16
-howl.log.MaximumBlocksPerFile    300
+howl.log.MaximumBlocksPerFile    1000
 # set the following using a system property
 #howl.log.FileDirectory           .
 howl.log.FileName                jotm
-howl.log.MaximumFiles            540
+howl.log.MaximumFiles            20

--- a/narayana/ArjunaJTA/jta/etc/log4j.xml
+++ b/narayana/ArjunaJTA/jta/etc/log4j.xml
@@ -14,7 +14,7 @@
 
     <appender name="file" class="org.apache.log4j.FileAppender">
         <param name="File" value="logs/test.log"/>
-        <param name="Append" value="false"/>
+        <param name="Append" value="true"/>
         <param name="Threshold" value="WARN"/>
 
         <layout class="org.apache.log4j.PatternLayout">


### PR DESCRIPTION
Three commits are here. 
* The reconfiguration of the howl log will hopefully stop the rollbackexceptions and the hanging run
* The change to Narayana objectstore would hopefully help for higher thread counts
* The change to log4j stops log4j clearing the log file each time