### PR TITLE
JBTM-3348:Adding progress logs to the performance benchmark script

### DIFF
--- a/narayana/scripts/hudson/bm.sh
+++ b/narayana/scripts/hudson/bm.sh
@@ -23,6 +23,7 @@ function runs {
     for bf in 300 2000 4000 7812; do
       cmp_narayana $threads 500 $bf true r-${threads}-${bf}.txt
       cmp_narayana $threads 1 $bf false r.txt $tput
+      echo "$(date): $threads threads and $bf buffer flushes"
     done
   done
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3348

Added some information in the script logging for each benchmark iteration like completion time (which is in milliseconds), completion percentage (here the benchmark execution completion percent is not based on execution time of each benchmark, I guess we need old average execution details to predict the execution completion percentage, for now it is just according to the iteration count)