### PR TITLE
upgrade JMH version and document env variables

### DIFF
--- a/narayana/README.md
+++ b/narayana/README.md
@@ -14,10 +14,6 @@ Now clone and build the narayana performance git repository:
     cd performance/narayana
     mvn clean install -DskipTests
 
-Many benchmarks also double up as junit tests so if you just want to validate that the benchmark runs then execute it as a surefire test. For example:
-
-    mvn -f ArjunaJTA/jta/pom.xml -Dtest=com.arjuna.ats.jta.xa.performance.VolatileStoreBenchmark test
-
 Each maven module build produces a benchmarks.jar file in the target directory which contains the benchmark code and the dependencies required by the benchmark. Just run this jar to execute a benchmark. To see what options are available pass the -help argument to any benchmark jar, for example:
 
     java -jar ./ArjunaJTA/jta/target/benchmarks.jar -help

--- a/narayana/pom.xml
+++ b/narayana/pom.xml
@@ -35,7 +35,7 @@ Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
 	<maven.compiler.target>11</maven.compiler.target>
-        <jmh.version>1.23</jmh.version>
+        <jmh.version>1.35</jmh.version>
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
         <version.org.jboss.jboss-transaction-spi>7.5.1.Final</version.org.jboss.jboss-transaction-spi>
         <version.junit>[4.13.1,)</version.junit>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3623

This PR was raised after a request to explain how the JMH run script works. The extra documentation is minimal and must be read in conjunction with the bash scripts (since the code is the canonical source of documentation).

I also upgraded JMH and removed the reference to the junit in the narayana/README.md file

depends on #152 so the Hold label can be removed when that gets merged (and this PR is re-based).