### PR TITLE
[JBTM-3366] When a benchmark fails it does not cause the build to fail

### DIFF
--- a/narayana/README.md
+++ b/narayana/README.md
@@ -22,6 +22,10 @@ For example, to run the VolatileStore benchmarks type the following:
 
     java  -jar ./ArjunaJTA/jta/target/benchmarks.jar com.arjuna.ats.jta.xa.performance.VolatileStoreBenchmark.* -i 1 -wi 2 -f 1 -t 2 -r 10
  
+To run the VolatileStore benchmarks, failing immediately if any benchmark had experienced an unrecoverable error, type the following :
+ 
+    java  -jar ./ArjunaJTA/jta/target/benchmarks.jar com.arjuna.ats.jta.xa.performance.VolatileStoreBenchmark.* -i 1 -wi 2 -f 1 -t 2 -r 10 -foe true
+     
 Here we have overridden the defaults and specified "-i 1 -wi 2 -f 1 -t 2 -r 10" which means:
   * run one iteration (-i 1) with 2 warm up cycles (-wi 2) and 1 fork (-f 1);
   * use 2 threads (-t 2) to execute the benchmark code;

--- a/narayana/scripts/hudson/benchmark.sh
+++ b/narayana/scripts/hudson/benchmark.sh
@@ -1,5 +1,9 @@
+#!/bin/bash -x
+
 [ ! -z "${THREAD_COUNTS}" ] && THREAD_ARG=`echo $THREAD_COUNTS | cut -f 1 -d " "` || THREAD_ARG="240"
-[ -z "${JMHARGS}" ] && JMHARGS="-t $THREAD_ARG -r 30 -f 3 -wi 5 -i 5"
+[ -z "${JMHARGS}" ] && JMHARGS="-t $THREAD_ARG -r 30 -f 3 -wi 5 -i 5 -foe true"
+
+#-foe true make the benchmark fail at the first exception
 
 function fatal {
   echo "$1"

--- a/narayana/scripts/hudson/bm.sh
+++ b/narayana/scripts/hudson/bm.sh
@@ -1,12 +1,15 @@
+#!/bin/bash
+
 # use this script to perform different runs using different tunable config parameters. It is useful for determining the best config.
 
 function cmp_narayana {
   XARGS="-DHornetqJournalEnvironmentBean.maxIO=$2 -DHornetqJournalEnvironmentBean.bufferFlushesPerSecond=$3 -DHornetqJournalEnvironmentBean.asyncIO=$4"
   if [ -z "${JMHARGS}" ] ; then
-   JMHARGS="-t $1 -r 30 -f 3 -wi 5 -i 5"
+   JMHARGS="-t $1 -r 30 -f 3 -wi 5 -i 5 -foe true "
   fi
   echo "Running JMHARGS="-t $1 ${JMHARGS/-t*-r/ -r}" ./narayana/scripts/hudson/benchmark.sh "ArjunaJTA/jta" "io.narayana.perf.product.NarayanaComparison.*" 1 "$XARGS" > $5"
   JMHARGS="-t $1 ${JMHARGS/-t*-r/ -r}" ./narayana/scripts/hudson/benchmark.sh "ArjunaJTA/jta" "io.narayana.perf.product.NarayanaComparison.*" 1 "$XARGS" > $5
+  res=$?
   field=4
   if grep "Measurement: 1 iterations" $5; then
     field=3
@@ -38,9 +41,14 @@ function runs {
   for threads in $THREAD_COUNTS; do
     for bf in $BF_COUNTS; do
       cmp_narayana $threads 500 $bf true r-${threads}-500-${bf}-true.txt
+      [ $? = 0 ] || res=1
       cmp_narayana $threads 1 $bf false r-${threads}-1-${bf}-false.txt $tput
+      [ $? = 0 ] || res=1
     done
   done
+  return $res
 }
 
+res=0
 runs
+exit $res

--- a/narayana/scripts/hudson/jenkins.sh
+++ b/narayana/scripts/hudson/jenkins.sh
@@ -136,7 +136,7 @@ fi
 for i in $THREAD_COUNTS
 do
   if [ -z "${JMHARGS}" ] ; then
-   JMHARGS="-t $i -r 30 -f 3 -wi 5 -i 5"
+   JMHARGS="-t $i -r 30 -f 3 -wi 5 -i 5 -foe true "
   fi
   JMHARGS="-t $i ${JMHARGS/-t*-r/ -r}" bm bm-output.txt $COMPARISON $COMPARISON_COUNT
 done


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3366
Adding '-foe true' flag as default in the JMH benchmark execution in order to save the benchmark's exit code and fail the pipeline if errors occur ( at the end of the pipeline) 
Adding some extra logging for benchmark.sh script