### PR TITLE
replace mvn package with mvn install

### DIFF
--- a/narayana/scripts/hudson/jenkins.sh
+++ b/narayana/scripts/hudson/jenkins.sh
@@ -117,7 +117,7 @@ if [ -v OVERRIDE_NARAYANA_VERSION ]; then
 fi
 
 # build the narayana project
-./build.sh -f narayana/pom.xml clean package -DskipTests $MAVEN_OVERRIDE_NARAYANA_VERSION
+./build.sh -f narayana/pom.xml clean install -DskipTests $MAVEN_OVERRIDE_NARAYANA_VERSION
 
 rm -f bm-output.txt benchmark-output.txt benchmark.png
 

--- a/scripts/hudson/jenkins.sh
+++ b/scripts/hudson/jenkins.sh
@@ -106,7 +106,7 @@ if [ -z $COMPARE_IMPLEMENTATIONS ] || [ $COMPARE_IMPLEMENTATIONS == "y" ]; then
 fi
 
 cd $WORKSPACE
-./build.sh package -f narayana
+./build.sh clean install -f narayana
 JVM_ARGS="-DMAX_ERRORS=10" ./narayana/scripts/hudson/benchmark.sh "ArjunaJTA/jta" "org.jboss.narayana.rts.*TxnTest.*" 3
 [ $? = 0 ] || fatal "RTS benchmark failed"
 mv benchmark-output.txt benchmark-rts-output.txt
@@ -117,7 +117,7 @@ if [ -v OVERRIDE_NARAYANA_VERSION ]; then
 fi
 
 if [ -z $COMPARE_TRANSPORTS ] || [ $COMPARE_TRANSPORTS == "y" ] || [ -z $COMPARE_JOURNAL_PARAMETERS ] || [ $COMPARE_JOURNAL_PARAMETERS == "y" ]; then
-	./build.sh -f narayana/pom.xml clean package -DskipTests $MAVEN_OVERRIDE_NARAYANA_VERSION
+	./build.sh clean install -f narayana/pom.xml -DskipTests $MAVEN_OVERRIDE_NARAYANA_VERSION
 fi
 
 if [ -z $COMPARE_TRANSPORTS ] || [ $COMPARE_TRANSPORTS == "y" ]; then

--- a/scripts/run_bm.sh
+++ b/scripts/run_bm.sh
@@ -88,12 +88,12 @@ if [ -v OVERRIDE_NARAYANA_VERSION ]; then
 fi
 
 function generate_csv_files {
-  ${WORKSPACE}/build.sh -f narayana/pom.xml package -DskipTests $MAVEN_OVERRIDE_NARAYANA_VERSION # build the benchmarks uber jar
+  ${WORKSPACE}/build.sh -f narayana/pom.xml clean install -DskipTests $MAVEN_OVERRIDE_NARAYANA_VERSION # build the benchmarks uber jar
   run_benchmarks pr # run the benchmarks against the local maven repo (should be the PR)
   
   build_narayana
 
-  ${WORKSPACE}/build.sh -f narayana/pom.xml package -DskipTests # build the benchmarks uber jar
+  ${WORKSPACE}/build.sh -f narayana/pom.xml clean install -DskipTests # build the benchmarks uber jar
   run_benchmarks master # run the benchmarks against this build of master
 }
 


### PR DESCRIPTION
Since the build.sh does not contain the package case it will execute install and package (redundancy) causing maven-jar-plugin error (since version 3.x):  "You have to use a classifier to attach supplemental artifacts to the project instead of replacing them"