### PR TITLE
[JBTM-3761] Adding jakarta transaction api dependency and bom

### DIFF
--- a/comparison/common/pom.xml
+++ b/comparison/common/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${version.jakarta.ws.rs-api}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
@@ -34,7 +33,6 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${version.jakarta.xml.bind-api}</version>
         </dependency>
     </dependencies>
 </project>

--- a/comparison/jts/pom.xml
+++ b/comparison/jts/pom.xml
@@ -26,18 +26,11 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${version.jakarta.ws.rs-api}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
-            <version>${version.jakarta.ejb-api}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -51,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -67,7 +60,6 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>${version.jakarta.annotation-api}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/comparison/jts/src/test/resources/arquillian.xml
+++ b/comparison/jts/src/test/resources/arquillian.xml
@@ -3,8 +3,6 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="Servlet 3.0"/>
-
     <group qualifier="wildfly-cluster">
         <container qualifier="server1" default="true" mode="manual">
             <configuration>

--- a/comparison/pom.xml
+++ b/comparison/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <!-- Server settings -->
-        <jvm.args.memory>-Xms64m -Xmx1024m -XX:MaxPermSize=512m</jvm.args.memory>
+        <jvm.args.memory>-Xms1024m -Xmx2048m </jvm.args.memory>
         <jvm.args.debug>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</jvm.args.debug>
         <jvm.args.other>-server</jvm.args.other>
 

--- a/comparison/pom.xml
+++ b/comparison/pom.xml
@@ -20,19 +20,8 @@
         <jvm.args.other>-server</jvm.args.other>
 
         <!-- Dependency versions -->
-        <version.arquillian>1.4.1.Final</version.arquillian>
-        <version.arquillian.wildfly.container>2.1.1.Final</version.arquillian.wildfly.container>
-        <version.wildfly.core>7.0.0.Final</version.wildfly.core>
         <version.org.jboss.narayana>6.0.1.Final-SNAPSHOT</version.org.jboss.narayana>
-        <version.jakarta.ejb-api>4.0.1</version.jakarta.ejb-api>
-        <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
-        <version.org.jboss.resteasy>6.2.2.Final</version.org.jboss.resteasy>
-        <version.junit>[4.13.1,)</version.junit>
-        <version.jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-api>
-        <version.org.jboss-jakarta-xml-ws-api_4.0_spec>1.0.0.Final</version.org.jboss-jakarta-xml-ws-api_4.0_spec>
-        <version.jakarta.annotation-api>2.1.1</version.jakarta.annotation-api>
-        <version.jaxws-ri>2.3.5</version.jaxws-ri>
-        <version.jakarta.xml.bind-api>4.0.0</version.jakarta.xml.bind-api>
+        <version.wildfly.core>20.0.0.Beta7</version.wildfly.core>
     </properties>
 
     <repositories>
@@ -55,58 +44,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jboss.narayana</groupId>
-                <artifactId>test-utils</artifactId>
-                <version>${version.org.jboss.narayana}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.narayana.rts</groupId>
-                <artifactId>restat-util</artifactId>
-                <version>${version.org.jboss.narayana}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.ejb</groupId>
-                <artifactId>jakarta.ejb-api</artifactId>
-                <version>${version.org.jboss.spec.javax.ejb}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.spec.javax.transaction</groupId>
-                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.transaction}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.ws.rs</groupId>
-                <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>${version.jakarta.ws.rs-api}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-client</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jaxb-provider</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${version.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${version.arquillian}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.arquillian</groupId>
-                <artifactId>wildfly-arquillian-container-managed</artifactId>
-                <version>${version.arquillian.wildfly.container}</version>
-            </dependency>
-            <dependency>
+		        <groupId>org.jboss.narayana</groupId>
+		        <artifactId>narayana-bom</artifactId>
+		        <version>${version.org.jboss.narayana}</version>
+		        <type>pom</type>
+		        <scope>import</scope>
+		    </dependency>
+		    <dependency>
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-cli</artifactId>
                 <classifier>client</classifier>

--- a/comparison/rest-at/pom.xml
+++ b/comparison/rest-at/pom.xml
@@ -30,18 +30,11 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${version.jakarta.ws.rs-api}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
-            <version>${version.jakarta.ejb-api}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -55,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -71,7 +64,6 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>${version.jakarta.annotation-api}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/comparison/rest-at/src/test/resources/arquillian.xml
+++ b/comparison/rest-at/src/test/resources/arquillian.xml
@@ -3,8 +3,6 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="Servlet 3.0"/>
-
     <group qualifier="wildfly-cluster">
         <container qualifier="server1" default="true" mode="manual">
             <configuration>

--- a/comparison/ws-at/pom.xml
+++ b/comparison/ws-at/pom.xml
@@ -26,36 +26,25 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${version.jakarta.ws.rs-api}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
-            <version>${version.jakarta.ejb-api}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.jakarta.xml.ws</groupId>
-            <artifactId>jboss-jakarta-xml-ws-api_4.0_spec</artifactId>
-            <version>${version.org.jboss-jakarta-xml-ws-api_4.0_spec}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>${version.jakarta.annotation-api}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-ri</artifactId>
-            <version>${version.jaxws-ri}</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -69,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/comparison/ws-at/src/test/resources/arquillian.xml
+++ b/comparison/ws-at/src/test/resources/arquillian.xml
@@ -3,8 +3,6 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="Servlet 3.0"/>
-
     <group qualifier="wildfly-cluster">
         <container qualifier="server1" default="true" mode="manual">
             <configuration>

--- a/narayana/ArjunaCore/arjuna/pom.xml
+++ b/narayana/ArjunaCore/arjuna/pom.xml
@@ -33,8 +33,6 @@
     <properties>
         <narayana.version>${project.version}</narayana.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.org.jboss.logging.jboss-logging>3.1.3.GA</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-processor>1.1.0.Final</version.org.jboss.logging.jboss-logging-processor>
     </properties>
 
     <repositories>
@@ -124,12 +122,10 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>${version.org.jboss.logging.jboss-logging}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
-            <version>${version.org.jboss.logging.jboss-logging-processor}</version>
         </dependency>
     </dependencies>
 </project>

--- a/narayana/ArjunaJTA/jta/pom.xml
+++ b/narayana/ArjunaJTA/jta/pom.xml
@@ -39,25 +39,18 @@
         <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
 
         <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
-        <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
-        <version.junit>[4.13.1,)</version.junit>
-        <version.com.h2database>2.1.210</version.com.h2database>
 
         <!-- RTS -->
         <narayana.version>${project.version}</narayana.version>
-        <undertow.io.version>2.2.19.Final</undertow.io.version>
-        <resteasy.version>6.2.2.Final</resteasy.version>
-        <resteasy.async-http-servlet.version>3.0.19.Final</resteasy.async-http-servlet.version>
 
         <!-- geronimo -->
         <version.org.apache.geronimo.components.geronimo-transaction>3.1.5</version.org.apache.geronimo.components.geronimo-transaction>
         <version.org.apache.geronimo.specs.geronimo-jta_1.1_spec>1.1.1</version.org.apache.geronimo.specs.geronimo-jta_1.1_spec>
-	<org.objectweb.howl-howl>1.0.1-1</org.objectweb.howl-howl>
+	    <org.objectweb.howl-howl>1.0.1-1</org.objectweb.howl-howl>
         <version.org.slf4j.slf4j-simple>1.6.4</version.org.slf4j.slf4j-simple>
         <version.org.slf4j.slf4j-api>1.7.5</version.org.slf4j.slf4j-api>
         <geronimo.version.org.slf4j.slf4j-simple>1.5.5</geronimo.version.org.slf4j.slf4j-simple>
 
-        <version.io.netty>4.1.79.Final</version.io.netty>
         <version.com.atomikos.transactions-jta>5.0.9</version.com.atomikos.transactions-jta>
         <version.com.atomikos.transactions-jdbc>5.0.9</version.com.atomikos.transactions-jdbc>
         <version.org.codehaus.btm.btm>2.1.4</version.org.codehaus.btm.btm>
@@ -91,7 +84,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -134,7 +126,6 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.3.2</version>
                     <configuration>
                 <source>11</source>
                 <target>11</target>
@@ -148,12 +139,10 @@
         <dependency>                                         
             <groupId>org.openjdk.jmh</groupId>               
             <artifactId>jmh-core</artifactId>                
-            <version>${jmh.version}</version>
         </dependency>                                        
         <dependency>                                         
             <groupId>org.openjdk.jmh</groupId>               
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>${jmh.version}</version>
             <scope>provided</scope>                          
         </dependency>                                        
         <dependency>
@@ -171,7 +160,6 @@
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-transaction-spi</artifactId>
-            <version>${version.org.jboss.jboss-transaction-spi}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jboss.logging</groupId>
@@ -197,23 +185,23 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-journal</artifactId>
-            <version>${version.org.apache.activemq}</version>
         </dependency>
+		<dependency>
+		    <groupId>jakarta.transaction</groupId>
+		    <artifactId>jakarta.transaction-api</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>${version.org.jboss.logging.jboss-logging}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${version.junit}</version>
         </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>${version.com.h2database}</version>
         </dependency>
 
         <!-- other products -->
@@ -295,15 +283,20 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${version.org.slf4j.slf4j-api}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${version.org.slf4j.slf4j-simple}</version>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.logging</groupId>
+			<artifactId>jboss-logging</artifactId>
+			<scope>compile</scope>
         </dependency>
 
         <!-- rts -->
@@ -321,17 +314,41 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${resteasy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client-api</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${resteasy.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-undertow</artifactId>
-            <version>${resteasy.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>jfree</groupId>
@@ -343,7 +360,6 @@
             <artifactId>jcommon</artifactId>
             <version>${version.jfreecommon}</version>
         </dependency>
-
-    </dependencies>
+	</dependencies>
 
 </project>

--- a/narayana/ArjunaJTA/jta/pom.xml
+++ b/narayana/ArjunaJTA/jta/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- JBoss, Home of Professional Open Source Copyright 2008, Red Hat Middleware 
-	LLC, and others contributors as indicated by the @authors tag. All rights 
-	reserved. See the copyright.txt in the distribution for a full listing of 
-	individual contributors. This copyrighted material is made available to anyone 
-	wishing to use, modify, copy, or redistribute it subject to the terms and 
-	conditions of the GNU Lesser General Public License, v. 2.1. This program 
-	is distributed in the hope that it will be useful, but WITHOUT A WARRANTY; 
-	without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
-	PURPOSE. See the GNU Lesser General Public License for more details. You 
-	should have received a copy of the GNU Lesser General Public License, v.2.1 
-	along with this distribution; if not, write to the Free Software Foundation, 
-	Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. -->
+    LLC, and others contributors as indicated by the @authors tag. All rights 
+    reserved. See the copyright.txt in the distribution for a full listing of 
+    individual contributors. This copyrighted material is made available to anyone 
+    wishing to use, modify, copy, or redistribute it subject to the terms and 
+    conditions of the GNU Lesser General Public License, v. 2.1. This program 
+    is distributed in the hope that it will be useful, but WITHOUT A WARRANTY; 
+    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+    PURPOSE. See the GNU Lesser General Public License for more details. You 
+    should have received a copy of the GNU Lesser General Public License, v.2.1 
+    along with this distribution; if not, write to the Free Software Foundation, 
+    Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
         <groupId>org.jboss.narayana</groupId>
@@ -46,7 +46,7 @@
         <!-- geronimo -->
         <version.org.apache.geronimo.components.geronimo-transaction>3.1.5</version.org.apache.geronimo.components.geronimo-transaction>
         <version.org.apache.geronimo.specs.geronimo-jta_1.1_spec>1.1.1</version.org.apache.geronimo.specs.geronimo-jta_1.1_spec>
-	    <org.objectweb.howl-howl>1.0.1-1</org.objectweb.howl-howl>
+        <org.objectweb.howl-howl>1.0.1-1</org.objectweb.howl-howl>
         <version.org.slf4j.slf4j-simple>1.6.4</version.org.slf4j.slf4j-simple>
         <version.org.slf4j.slf4j-api>1.7.5</version.org.slf4j.slf4j-api>
         <geronimo.version.org.slf4j.slf4j-simple>1.5.5</geronimo.version.org.slf4j.slf4j-simple>
@@ -93,12 +93,14 @@
                         <configuration>
                             <finalName>benchmarks</finalName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-								  <resource>META-INF/services/jakarta.ws.rs.ext.Providers</resource>
-								</transformer>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/services/jakarta.ws.rs.ext.Providers</resource>
+                                </transformer>
                             </transformers>
                         </configuration>
                     </execution>
@@ -110,8 +112,8 @@
                 <configuration>
                     <systemProperties>
                         <property>
-                          <name>com.atomikos.icatch.file</name>
-                          <value>${project.build.directory}/classes/atomikos.properties</value>
+                            <name>com.atomikos.icatch.file</name>
+                            <value>${project.build.directory}/classes/atomikos.properties</value>
                         </property>
                     </systemProperties>
 
@@ -124,34 +126,34 @@
                 </configuration>
             </plugin>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                <source>11</source>
-                <target>11</target>
-              </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
             </plugin>
 
         </plugins>
     </build>
 
     <dependencies>
-        <dependency>                                         
-            <groupId>org.openjdk.jmh</groupId>               
-            <artifactId>jmh-core</artifactId>                
-        </dependency>                                        
-        <dependency>                                         
-            <groupId>org.openjdk.jmh</groupId>               
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <scope>provided</scope>                          
-        </dependency>                                        
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>${version.io.netty}</version>
         </dependency>
-        <!-- JTA (local: ArjunaJTA/jta and remote: ArjunaJTS/jtax) need JTA and
-                JCA (for tx inflow) apis. -->
+        <!-- JTA (local: ArjunaJTA/jta and remote: ArjunaJTS/jtax) need JTA 
+            and JCA (for tx inflow) apis. -->
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
             <artifactId>jboss-transaction-api_1.2_spec</artifactId>
@@ -186,10 +188,10 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-journal</artifactId>
         </dependency>
-		<dependency>
-		    <groupId>jakarta.transaction</groupId>
-		    <artifactId>jakarta.transaction-api</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
@@ -229,7 +231,7 @@
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jta_1.1_spec</artifactId>
-                <version>${version.org.apache.geronimo.specs.geronimo-jta_1.1_spec}</version>
+            <version>${version.org.apache.geronimo.specs.geronimo-jta_1.1_spec}</version>
         </dependency>
         <dependency>
             <groupId>org.objectweb.howl</groupId>
@@ -283,20 +285,20 @@
                 </exclusion>
             </exclusions>
         </dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.logging</groupId>
-			<artifactId>jboss-logging</artifactId>
-			<scope>compile</scope>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <!-- rts -->
@@ -351,15 +353,15 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-          <groupId>jfree</groupId>
-          <artifactId>jfreechart</artifactId>
-          <version>${version.jfreechart}</version>
+            <groupId>jfree</groupId>
+            <artifactId>jfreechart</artifactId>
+            <version>${version.jfreechart}</version>
         </dependency>
         <dependency>
             <groupId>jfree</groupId>
             <artifactId>jcommon</artifactId>
             <version>${version.jfreecommon}</version>
         </dependency>
-	</dependencies>
+    </dependencies>
 
 </project>

--- a/narayana/pom.xml
+++ b/narayana/pom.xml
@@ -95,6 +95,13 @@ Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
     <dependencyManagement>
         <dependencies>
             <dependency>
+		        <groupId>org.jboss.narayana</groupId>
+		        <artifactId>narayana-bom</artifactId>
+		        <version>6.0.1.Final-SNAPSHOT</version>
+		        <type>pom</type>
+		        <scope>import</scope>
+		    </dependency>
+            <dependency>
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-core</artifactId>
                 <version>${jmh.version}</version>

--- a/narayana/tools/pom.xml
+++ b/narayana/tools/pom.xml
@@ -39,18 +39,15 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.narayana</groupId>
       <artifactId>common</artifactId>
-      <version>${narayana.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
-      <version>${version.org.jboss.logging.jboss-logging}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/scripts/hudson/performance-rebase.sh
+++ b/scripts/hudson/performance-rebase.sh
@@ -30,7 +30,7 @@ function rebase_performance {
   rm -rf .git/rebase-apply
   git clean -f -d -x
   
-  export BRANCHPOINT=master
+  export BRANCHPOINT=main
 
   # Update the pull to head  
   git pull --rebase --ff-only origin $BRANCHPOINT


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3761
Use dependency management in performance repo (Narayana bom)
jakarta.transaction-api dependency is needed in order to compile ArjunaJTA module