### PR TITLE
Narayana default branch is main

### DIFF
--- a/narayana/scripts/hudson/jenkins.sh
+++ b/narayana/scripts/hudson/jenkins.sh
@@ -20,11 +20,11 @@ function build_narayana {
       then
       if [ ! -d narayana-tmp ]; then
         NARAYANA_REPO=${NARAYANA_REPO:-jbosstm}
-        NARAYANA_BRANCH="${NARAYANA_BRANCH:-${GIT_BRANCH}}"
+        NARAYANA_BRANCH="${NARAYANA_BRANCH:-main}"
         git clone https://github.com/${NARAYANA_REPO}/narayana.git -b ${NARAYANA_BRANCH} narayana-tmp
         [ $? = 0 ] || fatal "git clone https://github.com/${NARAYANA_REPO}/narayana.git failed"
       else
-        NARAYANA_BRANCH="${NARAYANA_BRANCH:-${GIT_BRANCH}}"
+        NARAYANA_BRANCH="${NARAYANA_BRANCH:-main}"
         cd narayana-tmp
         git checkout ${NARAYANA_BRANCH}
         git fetch origin

--- a/scripts/hudson/jenkins.sh
+++ b/scripts/hudson/jenkins.sh
@@ -33,11 +33,11 @@ function build_narayana {
       then
       if [ ! -d narayana-tmp ]; then
         NARAYANA_REPO=${NARAYANA_REPO:-jbosstm}
-        NARAYANA_BRANCH="${NARAYANA_BRANCH:-${GIT_BRANCH}}"
+        NARAYANA_BRANCH="${NARAYANA_BRANCH:-main}"
         git clone https://github.com/${NARAYANA_REPO}/narayana.git -b ${NARAYANA_BRANCH} narayana-tmp
         [ $? = 0 ] || fatal "git clone https://github.com/${NARAYANA_REPO}/narayana.git failed"
       else
-        NARAYANA_BRANCH="${NARAYANA_BRANCH:-${GIT_BRANCH}}"
+        NARAYANA_BRANCH="${NARAYANA_BRANCH:-main}"
         cd narayana-tmp
         git checkout ${NARAYANA_BRANCH}
         git fetch origin

--- a/scripts/run_bm.sh
+++ b/scripts/run_bm.sh
@@ -29,11 +29,11 @@ function build_narayana {
       then
       if [ ! -d narayana-tmp ]; then
         NARAYANA_REPO=${NARAYANA_REPO:-jbosstm}
-        NARAYANA_BRANCH="${NARAYANA_BRANCH:-${GIT_BRANCH}}"
+        NARAYANA_BRANCH="${NARAYANA_BRANCH:-main}"
         git clone https://github.com/${NARAYANA_REPO}/narayana.git -b ${NARAYANA_BRANCH} narayana-tmp
         [ $? = 0 ] || fatal "git clone https://github.com/${NARAYANA_REPO}/narayana.git failed"
       else
-        NARAYANA_BRANCH="${NARAYANA_BRANCH:-${GIT_BRANCH}}"
+        NARAYANA_BRANCH="${NARAYANA_BRANCH:-main}"
         cd narayana-tmp
         git checkout ${NARAYANA_BRANCH}
         git fetch origin


### PR DESCRIPTION
GIT_BRANCH is a Jenkins environment variable and it is set as the performance job branch/PR number.
It is better to set the Narayana default branch to main instead 'GIT_BRANCH'. Currently the default branch is the Performance branch, which causes "Remote branch ... not found " error (i.e. https://ci-jenkins-csb-narayana.apps.ocp-c1.prod.psi.redhat.com/job/btny-pulls-performance/7/console).
P.S. When contributors wants to test the performance PR against a specific Narayana PR they need to set in the performance PR's description the url of the Narayana PR.

See git | Jenkins plugin environment variables (https://plugins.jenkins.io/git/#plugin-content-environment-variables)