### PR TITLE
[GHA] performance workflow requires JDK 25

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -29,10 +29,8 @@ on:
         required: true
         type: choice
         options:
-          - '21'
-          - '17'
-          - '11'
-        default: '21'
+          - '25'
+        default: '25'
       pull_request_repo:
         description: 'Repository to check out'
         required: false


### PR DESCRIPTION
[GHA] require JDK 25 when manually triggering a performance run

pr/237 added a manual trigger for performance run but it should have constrained the JDK to use Java 25

NO_TESTS
